### PR TITLE
Add `dist` and `.DS_Store` into .gitignore

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,6 +101,8 @@ async function main() {
         `node_modules
 temp
 build
+dist
+.DS_Store
 `
     );
 


### PR DESCRIPTION
 * `dist` is being created when you compile all the Typescript sources
 * `.DS_Store` is being created by system on macOS
 
 Would be nice to have them in .gitignore