### PR TITLE
fix: disabled caching to prevent old Tact files from being used after a rebuild

### DIFF
--- a/template/jest.config.ts
+++ b/template/jest.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'jest';
 const config: Config = {
     preset: 'ts-jest',
     globalSetup: './jest.setup.ts',
+    cache: false, // disabled caching to prevent old Tact files from being used after a rebuild
     testEnvironment: 'node',
     testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };


### PR DESCRIPTION
Closes https://github.com/ton-org/blueprint/issues/212