### PR TITLE
feat: add default project name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,12 +46,15 @@ export async function main() {
         // and creation of the first contract via Blueprint
     });
 
+    const defaultProjectName = path.basename(path.resolve(''));
+
     const desiredProjectName: string =
         localArgs._[0] ||
         (
             await inquirer.prompt({
                 name: 'name',
                 message: 'Project name',
+                default: defaultProjectName,
             })
         ).name.trim();
 
@@ -59,7 +62,9 @@ export async function main() {
 
     const name = path.basename(projectPath);
 
-    if (name.length === 0) throw new Error('Cannot initialize a project with an empty name');
+    if (desiredProjectName.length === 0 || name.length === 0) {
+        throw new Error('Cannot initialize a project with an empty name');
+    }
 
     const noCi = localArgs['--no-ci'] ?? false;
 


### PR DESCRIPTION
## Issue

Now, if you specify an empty name, the name of the folder where `create-ton` was launched will be implicitly selected as the project name.

I think it's useful, but now I'm clearly stating it:
<img width="316" height="86" alt="Screenshot 2025-10-02 at 23 46 03" src="https://github.com/user-attachments/assets/a463c6f6-8f18-464e-8e3e-0e1791f5a9ef" />


I also fixed bug #46, where it was possible to specify an empty name for a project. Yes, the current folder is calculated there, but it's a little strange, so it's better to disable this behavior.

## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [ ] Documented the contribution in `README.md`
* [ ] Added tests to demonstrate correct behavior (both positive and negative cases)
* [x] All tests pass successfully (`yarn test`)
* [x] Code passes linting checks (`yarn lint`)
