### PR TITLE
chore: deprecate `FunC` and `Tact` templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ If you want to input data non-interactively (for example, in scripts), do:
 ```bash
 npm create ton@latest -- project-dir --type first-contract-type --contractName FirstContractName
 ```
-where `first-contract-type` can currently be one of `tolk-empty`, `tolk-counter`, `func-empty`, `func-counter`, `tact-empty`, `tact-counter`
+where `first-contract-type` can currently be one of `tolk-empty`, `tolk-counter`, `func-empty` (deprecated), `func-counter` (deprecated), `tact-empty` (deprecated), `tact-counter` (deprecated)
 
 For more details please go to https://ton-blockchain.github.io/acton/

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,11 +27,11 @@ const VARIANT_CHOICES = [
         value: 'tolk-empty',
     },
     {
-        name: 'An empty contract (FunC)',
+        name: 'An empty contract (FunC, deprecated)',
         value: 'func-empty',
     },
     {
-        name: 'An empty contract (Tact)',
+        name: 'An empty contract (Tact, deprecated)',
         value: 'tact-empty',
     },
     {
@@ -39,11 +39,11 @@ const VARIANT_CHOICES = [
         value: 'tolk-counter',
     },
     {
-        name: 'A simple counter contract (FunC)',
+        name: 'A simple counter contract (FunC, deprecated)',
         value: 'func-counter',
     },
     {
-        name: 'A simple counter contract (Tact)',
+        name: 'A simple counter contract (Tact, deprecated)',
         value: 'tact-counter',
     },
 ];


### PR DESCRIPTION
## Issue

Closes #<issue-number>

## Checklist

Please ensure the following items are completed before requesting review:

* [ ] Updated `CHANGELOG.md` with relevant changes
* [ ] Documented the contribution in `README.md`
* [ ] Added tests to demonstrate correct behavior (both positive and negative cases)
* [ ] All tests pass successfully (`yarn test`)
* [ ] Code passes linting checks (`yarn lint`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project creation docs to clearly mark older contract type options as deprecated.
* **New Features**
  * Updated the CLI template list so deprecated FunC and Tact variants are labeled as such in the prompt, while behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->